### PR TITLE
Configure release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  push:
+    tags: [ "v*" ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    runs-on: ${{ matrix.os }}
+    name: Release ${{ matrix.target }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Determine release type
+        id: release-type
+        run: |
+          if [[ ${{ github.ref }} =~ ^refs/tags/[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo 'type=release' >> "$GITHUB_OUTPUT"
+          else
+            echo 'type=prerelease' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v3
+        with:
+          path: cli/target
+          key: ${{ runner.os }}-release-cargo-${{ hashFiles('cli/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-release-cargo
+
+      - name: Build CLI app
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --manifest-path=cli/Cargo.toml --release --target=${{ matrix.target }} --all-features --locked
+      - name: Package archive
+        id: package
+        run: ./cli/package.sh ${REF#"refs/tags/"}
+        env:
+          OS: ${{ matrix.os }}
+          TARGET: ${{ matrix.target }}
+          REF: ${{ github.ref }}
+      - name: Publish archive
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          files: ${{ steps.package.outputs.archive }}
+          prerelease: ${{ steps.release-type.outputs.type == 'prerelease' }}

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.3.0-beta.1 - 2023-01-19
+
 ### Added
 
 - Add ability to customize the rendering template using `--tpl <path>` option.
@@ -20,6 +22,8 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 - Support line numbering with the help of the `--line-numbers` / `-n` option.
 - Add a Docker image for the CLI app
   on the [GitHub Container registry](https://github.com/slowli/term-transcript/pkgs/container/term-transcript).
+- Add prebuilt binaries for popular targets (x86_64 for Linux / macOS / Windows
+  and aarch64 for macOS) available from [GitHub releases](https://github.com/slowli/term-transcript/releases).
 
 ### Changed
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,5 +37,8 @@ portable-pty = ["term-transcript/portable-pty"]
 # Enables tracing for main operations.
 tracing = ["tracing-subscriber", "term-transcript/tracing"]
 
+[profile.release]
+strip = true
+
 [workspace]
 # Separate workspace since we need a lockfile

--- a/cli/README.md
+++ b/cli/README.md
@@ -18,7 +18,10 @@ cargo install --locked term-transcript-cli
 term-transcript --help
 ```
 
-Alternatively, you may use the app Docker image [as described below](#using-docker-image).
+Alternatively, you may use the app Docker image [as described below](#using-docker-image),
+or download a pre-built app binary for popular targets (x86_64 for Linux / macOS / Windows
+and AArch64 for macOS)
+from [GitHub Releases](https://github.com/slowli/term-transcript/releases).
 
 ### Crate feature: `portable-pty`
 

--- a/cli/package.sh
+++ b/cli/package.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Script to create an archive with the release contents (the `term-transcript` executable
+# and the supporting docs).
+
+set -e
+
+VERSION=$1
+if [[ "$VERSION" == '' ]]; then
+  echo "Error: release version is not specified"
+  exit 1
+fi
+echo "Packaging term-transcript $VERSION for $TARGET..."
+
+CLI_DIR=$(dirname "$0")
+RELEASE_DIR="$CLI_DIR/release"
+EXECUTABLE="$CLI_DIR/target/$TARGET/release/term-transcript"
+
+if [[ "$OS" == 'windows-latest' ]]; then
+  EXECUTABLE="$EXECUTABLE.exe"
+fi
+if [[ ! -x $EXECUTABLE ]]; then
+  echo "Error: executable $EXECUTABLE does not exist"
+  exit 1
+fi
+
+rm -rf "$RELEASE_DIR" && mkdir "$RELEASE_DIR"
+echo "Copying release files to $RELEASE_DIR..."
+cp "$EXECUTABLE" \
+  "$CLI_DIR/README.md" \
+  "$CLI_DIR/CHANGELOG.md" \
+  "$CLI_DIR/LICENSE-APACHE" \
+  "$CLI_DIR/LICENSE-MIT" \
+  "$RELEASE_DIR"
+
+cd "$RELEASE_DIR"
+echo "Creating release archive..."
+case $OS in
+  ubuntu-latest | macos-latest)
+    ARCHIVE="term-transcript-$VERSION-$TARGET.tar.gz"
+    tar czf "$ARCHIVE" ./*
+    ;;
+  windows-latest)
+    ARCHIVE="term-transcript-$VERSION-$TARGET.zip"
+    7z a "$ARCHIVE" ./*
+    ;;
+  *)
+    echo "Unknown target: $TARGET"
+    exit 1
+esac
+ls -l "$ARCHIVE"
+
+if [[ "$GITHUB_OUTPUT" != '' ]]; then
+  echo "Outputting path to archive as GitHub step output: $RELEASE_DIR/$ARCHIVE"
+  echo "archive=$RELEASE_DIR/$ARCHIVE" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
Adds a GitHub workflow that attaches pre-built CLI app for 4 common targets (`x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`).