### PR TITLE
chore: Prepare 0.5.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,7 +1217,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "styled-str"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "term-transcript"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "term-transcript-cli"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "term-transcript-rainbow"
-version = "0.5.0-beta.1"
+version = "0.5.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1349,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "test-casing"
-version = "0.2.0-beta.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3daeaea95548ac27e70c4e55f6bd871d69ba6463af5d73b9b627b44f8b520adc"
+checksum = "d058c299f55101cd3a8abb6cec8eaf4f047fe36346668fffe1ed65b6572060ec"
 dependencies = [
  "test-casing-macro",
  "tracing",
@@ -1360,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "test-casing-macro"
-version = "0.2.0-beta.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff5b5423c2f88c9fc1c139eda0e1f13b88367e9b5eb53d03f5f640f7d23070e"
+checksum = "efd174360feb5ee2613457f9769030e89c4a2551ff8d91afea7932e90a9ad630"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0-beta.1"
+version = "0.5.0"
 authors = ["Alex Ostrovski <ostrovski.alex@gmail.com>"]
 edition = "2024"
 rust-version = "1.86"
@@ -40,7 +40,7 @@ quick-xml = "0.41.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.27.0"
-test-casing = "=0.2.0-beta.1"
+test-casing = "0.2.0"
 toml = "1.1.2"
 tracing = "0.1.44"
 tracing-capture = "0.1.0"
@@ -49,8 +49,8 @@ unicode-width = "0.2"
 version-sync = "0.9.2"
 
 # Workspace dependencies
-styled-str = { version = "=0.5.0-beta.1", path = "crates/styled-str" }
-term-transcript = { version = "=0.5.0-beta.1", path = "crates/term-transcript" }
+styled-str = { version = "0.5.0", path = "crates/styled-str" }
+term-transcript = { version = "0.5.0", path = "crates/term-transcript" }
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/crates/styled-str/CHANGELOG.md
+++ b/crates/styled-str/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## 0.5.0 - 2026-07-18
+
+The initial release of `styled-str`.

--- a/crates/styled-str/README.md
+++ b/crates/styled-str/README.md
@@ -26,7 +26,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-styled-str = "0.5.0-beta.1"
+styled-str = "0.5.0"
 ```
 
 Basic usage:

--- a/crates/styled-str/src/lib.rs
+++ b/crates/styled-str/src/lib.rs
@@ -154,7 +154,7 @@
 //! [CSI]: https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
 
 // Documentation settings
-#![doc(html_root_url = "https://docs.rs/styled-str/0.5.0-beta.1")]
+#![doc(html_root_url = "https://docs.rs/styled-str/0.5.0")]
 // Conditional compilation
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate core;

--- a/crates/term-transcript-cli/CHANGELOG.md
+++ b/crates/term-transcript-cli/CHANGELOG.md
@@ -5,6 +5,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.5.0 - 2026-07-18
+
+*(No substantial changes compared to the [0.5.0-beta.1 release](#050-beta1---2026-02-04))*
+
 ## 0.5.0-beta.1 - 2026-02-04
 
 ### Added

--- a/crates/term-transcript-cli/tests/snapshots/test-fail.svg
+++ b/crates/term-transcript-cli/tests/snapshots/test-fail.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 720 560.8" width="720" height="560.8" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/crates/term-transcript/CHANGELOG.md
+++ b/crates/term-transcript/CHANGELOG.md
@@ -5,6 +5,10 @@ The project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## 0.5.0 - 2026-07-18
+
+*(All changes are relative compared to the [0.5.0-beta.1 release](#050-beta1---2026-02-04))*
+
 ### Added
 
 - Add ability to test captured CLI transcripts.

--- a/crates/term-transcript/README.md
+++ b/crates/term-transcript/README.md
@@ -29,7 +29,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-term-transcript = "0.5.0-beta.1"
+term-transcript = "0.5.0"
 ```
 
 Example of usage:

--- a/crates/term-transcript/src/lib.rs
+++ b/crates/term-transcript/src/lib.rs
@@ -149,7 +149,7 @@
 //! ```
 
 // Documentation settings.
-#![doc(html_root_url = "https://docs.rs/term-transcript/0.5.0-beta.1")]
+#![doc(html_root_url = "https://docs.rs/term-transcript/0.5.0")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "portable-pty")]

--- a/crates/term-transcript/src/svg/data.rs
+++ b/crates/term-transcript/src/svg/data.rs
@@ -160,7 +160,7 @@ pub(super) struct StyledLine<'a> {
 /// let expected_json = serde_json::json!({
 ///     "creator": {
 ///         "name": "term-transcript",
-///         "version": "0.5.0-beta.1",
+///         "version": "0.5.0",
 ///         "repo": "https://github.com/slowli/term-transcript",
 ///     },
 ///     "width": 720,

--- a/docs/src/assets/custom-config.svg
+++ b/docs/src/assets/custom-config.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 -22 929 342" width="929" height="342" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/embedded-font-fira.svg
+++ b/docs/src/assets/embedded-font-fira.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 382.8" width="749" height="382.8" xmlns="http://www.w3.org/2000/svg">
   <style>
     @font-face {

--- a/docs/src/assets/embedded-font-pure.svg
+++ b/docs/src/assets/embedded-font-pure.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 382.8" width="749" height="382.8" xmlns="http://www.w3.org/2000/svg">
   <style>
     @font-face {

--- a/docs/src/assets/embedded-font.svg
+++ b/docs/src/assets/embedded-font.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 363" width="749" height="363" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/failure-bash-pty.svg
+++ b/docs/src/assets/failure-bash-pty.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 -22 720 129.2" width="720" height="129.2" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/failure-pwsh.svg
+++ b/docs/src/assets/failure-pwsh.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 -22 720 136" width="720" height="136" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/failure-sh.svg
+++ b/docs/src/assets/failure-sh.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 -22 720 139.2" width="720" height="139.2" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/fira-pure.svg
+++ b/docs/src/assets/fira-pure.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 -22 720 354.4" width="720" height="354.4" xmlns="http://www.w3.org/2000/svg">
   <style>
 

--- a/docs/src/assets/fira.svg
+++ b/docs/src/assets/fira.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 -22 720 354.4" width="720" height="354.4" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/no-inputs-numbers-pure.svg
+++ b/docs/src/assets/no-inputs-numbers-pure.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 362" width="749" height="362" xmlns="http://www.w3.org/2000/svg">
   <style>
     .container {

--- a/docs/src/assets/no-inputs-numbers.svg
+++ b/docs/src/assets/no-inputs-numbers.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 362" width="749" height="362" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/numbers-continuous-outputs.svg
+++ b/docs/src/assets/numbers-continuous-outputs.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 362" width="749" height="362" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/numbers-continuous-pure.svg
+++ b/docs/src/assets/numbers-continuous-pure.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 362" width="749" height="362" xmlns="http://www.w3.org/2000/svg">
   <style>
     .container {

--- a/docs/src/assets/numbers-continuous.svg
+++ b/docs/src/assets/numbers-continuous.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 362" width="749" height="362" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/numbers-each-output.svg
+++ b/docs/src/assets/numbers-each-output.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 362" width="749" height="362" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/numbers-long-cont.svg
+++ b/docs/src/assets/numbers-long-cont.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 366" width="749" height="366" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/numbers-long-pure.svg
+++ b/docs/src/assets/numbers-long-pure.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 390" width="749" height="390" xmlns="http://www.w3.org/2000/svg">
   <style>
     .container {

--- a/docs/src/assets/numbers-long.svg
+++ b/docs/src/assets/numbers-long.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 749 390" width="749" height="390" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/rainbow-pure.svg
+++ b/docs/src/assets/rainbow-pure.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 720 332.4" width="720" height="332.4" xmlns="http://www.w3.org/2000/svg">
   <style>
     .container {

--- a/docs/src/assets/rainbow-small.svg
+++ b/docs/src/assets/rainbow-small.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 450 200" width="450" height="200" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/rainbow-wide.svg
+++ b/docs/src/assets/rainbow-wide.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 900 349.2" width="900" height="349.2" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/docs/src/assets/rainbow.html
+++ b/docs/src/assets/rainbow.html
@@ -141,7 +141,7 @@ Base colors (bg):
         </div>      </div>
     </main>
     <footer class="my-4 text-center">
-      <p><em class="small text-muted">Created with <a href="https://github.com/slowli/term-transcript">term-transcript v0.5.0-beta.1</a></em></p>
+      <p><em class="small text-muted">Created with <a href="https://github.com/slowli/term-transcript">term-transcript v0.5.0</a></em></p>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js" integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13" crossorigin="anonymous"></script>
   </body>

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -4,7 +4,7 @@ Add this to your `Crate.toml`:
 
 ```toml
 [dependencies]
-term-transcript = "0.5.0-beta.1"
+term-transcript = "0.5.0"
 ```
 
 See [the library docs](crates/term_transcript) for detailed description of its API.

--- a/e2e-tests/rainbow/repl.svg
+++ b/e2e-tests/rainbow/repl.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 720 162.8" width="720" height="162.8" xmlns="http://www.w3.org/2000/svg">
   <style>
     .container {

--- a/examples/animated.svg
+++ b/examples/animated.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 -22 720 384" width="720" height="384" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">

--- a/examples/rainbow.svg
+++ b/examples/rainbow.svg
@@ -1,4 +1,4 @@
-<!-- Created with term-transcript v0.5.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<!-- Created with term-transcript v0.5.0 (https://github.com/slowli/term-transcript) -->
 <svg viewBox="0 0 720 332.4" width="720" height="332.4" xmlns="http://www.w3.org/2000/svg">
   <switch>
     <g requiredExtensions="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION
## What?

Bumps crate versions to 0.5.0 (the next stable release).

## Why?

Makes sense to stabilize new functionality introduced in or after 0.5.0-beta.1.
